### PR TITLE
Converted SwinGame.h to Splashkit.h code

### DIFF
--- a/code/c/array/bubble-game.c
+++ b/code/c/array/bubble-game.c
@@ -1,14 +1,8 @@
 #include <stdio.h>
 #include <stdbool.h>
-#include "SwinGame.h"
+#include "splashkit.h"
 
 #define BUBBLE_COUNT 10
-
-// Load the bubble image
-void load_resources()
-{
-    load_bitmap_named("bubble", "bubble.png");
-}
 
 // Place a bubble somewhere on the screen, 
 // and give it a random movement
@@ -21,17 +15,12 @@ void place_bubble(sprite bubble)
 }
 
 // Create bubbles, and place them on the screen to start
-void populate_bubbles(sprite bubbles[], int sz)
+void populate_bubbles(sprite bubbles[], int sz, bitmap bubble)
 {
     int i;
-    int bubble_width, bubble_height;
-    
-    bubble_width = bitmap_width(bitmap_named("bubbles"));
-    bubble_height = bitmap_height(bitmap_named("bubbles"));
-    
     for (i = 0; i < sz; i++)
     {
-        bubbles[i] = create_sprite(bitmap_named("bubble"));
+        bubbles[i] = create_sprite(bubble);
         place_bubble(bubbles[i]);
     }
 }
@@ -51,7 +40,6 @@ void update_bubble(sprite bubble)
 void update_bubbles(sprite bubbles[], int sz)
 {
     int i;
-    
     for (i = 0; i < sz; i++)
     {
         update_bubble(bubbles[i]);
@@ -62,7 +50,6 @@ void update_bubbles(sprite bubbles[], int sz)
 void draw_bubbles(sprite bubbles[], int sz)
 {
     int i;
-    
     for (i = 0; i < sz; i++)
     {
         draw_sprite(bubbles[i]);
@@ -75,13 +62,11 @@ int main()
 {
     // Create an array of bubbles
     sprite bubbles[BUBBLE_COUNT];
-    
-    open_audio();
-    open_graphics_window("Bubble Pop!", 800, 600);
-    load_default_colors();
-    
-    load_resources();
-    populate_bubbles(bubbles, BUBBLE_COUNT);    // Load the bubbles
+    open_window("Bubble Pop!", 800, 600);
+
+    //Load and populate the bubble bitmap
+    bitmap bubble = load_bitmap("bubble", "Resources/images/bubble.png");
+    populate_bubbles(bubbles, BUBBLE_COUNT, bubble);    // Load the bubbles
     
     do
     {
@@ -91,15 +76,11 @@ int main()
         
         // Draw the game
         clear_screen();
-        
-        draw_framerate(0,0);
         draw_bubbles(bubbles, BUBBLE_COUNT);
         
-        refresh_screen();
-    } while ( ! window_close_requested() );
-    
-    close_audio();
-    
-    release_all_resources();
+        refresh_screen(60);
+
+    } while ( ! quit_requested() );
+
     return 0;
 }

--- a/code/c/storing-using-data/bike-race.c
+++ b/code/c/storing-using-data/bike-race.c
@@ -2,7 +2,7 @@
 
 #include <stdio.h>
 #include <stdbool.h>
-#include "SwinGame.h"
+#include "splashkit.h"
 
 // ====================
 // = Define constants =
@@ -75,26 +75,21 @@ void draw_bike(color bike_color, float x, float y)
 // Run the bike race...
 int main()
 {
-    open_audio();
-    open_graphics_window("Bicycle Race...", 800, 600);
-    load_default_colors();
+    open_window("Bicycle Race...", 800, 600);
     
     clear_screen();
     
-    draw_bike(ColorRed, bike_x_for_accel(random_accel()), 10);
-    draw_bike(ColorGreen, bike_x_for_accel(random_accel()), 60);
-    draw_bike(ColorBlue, bike_x_for_accel(random_accel()), 110);
-    draw_bike(rgbcolor(127, 127, 0), bike_x_for_accel(random_accel()), 160);
-    draw_bike(rgbcolor(127, 127, 127), bike_x_for_accel(random_accel()), 210);
-    draw_bike(rgbcolor(255, 255, 255), bike_x_for_accel(random_accel()), 260);
+    draw_bike(color_red(), bike_x_for_accel(random_accel()), 10);
+    draw_bike(color_green(), bike_x_for_accel(random_accel()), 60);
+    draw_bike(color_blue(), bike_x_for_accel(random_accel()), 110);
+    draw_bike(rgb_color(127, 127, 0), bike_x_for_accel(random_accel()), 160);
+    draw_bike(rgb_color(127, 127, 127), bike_x_for_accel(random_accel()), 210);
+    draw_bike(rgb_color(0, 0, 0), bike_x_for_accel(random_accel()), 260);
     draw_bike(random_color(), bike_x_for_accel(random_accel()), 310);
     
     refresh_screen();
     
     delay(5000);
     
-    close_audio();
-    
-    release_all_resources();
     return 0;
 }

--- a/code/c/storing-using-data/swingame-comet.c
+++ b/code/c/storing-using-data/swingame-comet.c
@@ -1,14 +1,14 @@
 #include <stdio.h>
 #include <stdbool.h>
-#include "SwinGame.h"
+#include "splashkit.h"
 
 // Constant values
 #define ECCENTRICITY 0.995f
 #define DISTANCE_POLE_DIRECTRIX 1.828f
 #define SUN_X 10
 #define SUN_Y 300
-#define SUN_RADIUS 2
-#define COMET_RADIUS 1
+#define SUN_RADIUS 30
+#define COMET_RADIUS 4
 #define MAX_DISTANCE 380.0f
 
 #define MIN_WAIT 100
@@ -62,12 +62,12 @@ void draw_comet(float angle)
     
     printf("Comet position (%f deg): %.1f,%.1f = %.1f,%.1f\n", angle, comet_x, comet_y, screen_x, screen_y);
     
-    fill_circle(ColorWhite, screen_x, screen_y, COMET_RADIUS);
+    fill_circle(color_white(), screen_x, screen_y, COMET_RADIUS);
 }
 
 void draw_sun()
 {
-    fill_circle(ColorYellow, SUN_X, SUN_Y, SUN_RADIUS);
+    fill_circle(color_yellow(), SUN_X, SUN_Y, SUN_RADIUS);
 }
 
 void delay_for_angle(float angle)
@@ -81,7 +81,7 @@ void delay_for_angle(float angle)
 
 void draw_system(float angle)
 {
-    clear_screen();
+    clear_screen(color_black());
     draw_sun();
     draw_comet(angle);
     refresh_screen();
@@ -90,9 +90,7 @@ void draw_system(float angle)
 
 int main()
 {
-    open_audio();
-    open_graphics_window("Hale-Bopp's Orbit", 800, 600);
-    load_default_colors();
+    open_window("Hale-Bopp's Orbit", 800, 600);
     
     draw_system(0);
     draw_system(45);
@@ -119,8 +117,5 @@ int main()
     draw_system(340);
     draw_system(360);
 
-    close_audio();
-    
-    release_all_resources();
     return 0;
 }

--- a/code/c/storing-using-data/water-tank.c
+++ b/code/c/storing-using-data/water-tank.c
@@ -1,4 +1,4 @@
-#include "SwinGame.h"
+#include "splashkit.h"
 
 #define MAX_HEIGHT 400
 #define MAX_WIDTH 200
@@ -21,28 +21,26 @@ void draw_water_tank(float x, float y, int width, int height, float pct_full)
     
     // Water...
     // Bottom ellipse
-    fill_ellipse(ColorBlue, x, bottom_ellipse_y, width, ellipse_height);
-    draw_ellipse(ColorBlack, x, bottom_ellipse_y, width, ellipse_height);
+    fill_ellipse(color_blue(), x, bottom_ellipse_y, width, ellipse_height);
+    draw_ellipse(color_black(), x, bottom_ellipse_y, width, ellipse_height);
     // Body - center of cylinder
-    fill_rectangle(ColorBlue, x, water_y, width, water_height);
+    fill_rectangle(color_blue(), x, water_y, width, water_height);
     //Top ellipse
-    fill_ellipse(ColorBlue, x, top_ellipse_y, width, ellipse_height);
-    draw_ellipse(ColorBlack, x, top_ellipse_y, width, ellipse_height);
+    fill_ellipse(color_blue(), x, top_ellipse_y, width, ellipse_height);
+    draw_ellipse(color_black(), x, top_ellipse_y, width, ellipse_height);
     
     // Frame
-    draw_ellipse(ColorBlack, x, y, width, ellipse_height);
-    draw_line(ColorBlack, x, y + ellipse_height / 2, x, bottom_ellipse_y + ellipse_height / 2);
-    draw_line(ColorBlack, x + width, y + ellipse_height / 2, x + width, bottom_ellipse_y + ellipse_height / 2);
+    draw_ellipse(color_black(), x, y, width, ellipse_height);
+    draw_line(color_black(), x, y + ellipse_height / 2, x, bottom_ellipse_y + ellipse_height / 2);
+    draw_line(color_black(), x + width, y + ellipse_height / 2, x + width, bottom_ellipse_y + ellipse_height / 2);
     
 }
 
 int main(int argc, char* argv[])
 {
-    open_audio();
-    open_graphics_window("Water Tanks", 800, 600);
-    load_default_colors();
-    
-    clear_screen(ColorWhite);
+    open_window("Water Tanks", 800, 600);
+
+    clear_screen(color_white());
     draw_water_tank(10, 50, 100, 200, 0.75);
     draw_water_tank(150, 50, 100, 300, 0.0);
     draw_water_tank(300, 50, 70, 100, 0.25);
@@ -50,8 +48,5 @@ int main(int argc, char* argv[])
     refresh_screen();
     
     delay(5000);
-
-    release_all_resources();
-    close_audio();
     return 0;
 }

--- a/code/c/types/complete_shape_drawing.cpp
+++ b/code/c/types/complete_shape_drawing.cpp
@@ -1,10 +1,10 @@
 /*
-* Program: Shape Drawer - SwinGame source file.
+* Program: Shape Drawer - Splashkit source file.
 */
 
 #include <stdio.h>
 #include <stdbool.h>
-#include "SwinGame.h"
+#include "splashkit.h"
 
 // =====================
 // = Declare Constants =
@@ -14,7 +14,7 @@
 // Menu Shape Constants
 const rectangle MENU_RECT = {10,250,40,50};
 const circle	MENU_CIRCLE = {{30,100},20};
-const triangle  MENU_TRIANGLE = {{30,150},{10,200},{50,200}};
+const triangle  MENU_TRIANGLE = triangle_from(30,150,10,200,50,200);
 const rectangle MENU_ELLIPSE = {10,350,40,50};
 const rectangle DRAWING_PAD = {61,0,790,600};
 
@@ -29,7 +29,8 @@ typedef enum
 	TRIANGLE,
 	RECTANGLE,
 	ELLIPSE,
-	UNKNOWN
+	//UNKNOWN
+	NONE
 } shape_type;
 
 // The Shape Data is either...
@@ -71,30 +72,30 @@ typedef struct
 void draw_shapes_menu(shape_type selected_shape)
 {
     // Draw the "toolbar" area
-	fill_rectangle(ColorLightGrey,0,0,60,600);
+	fill_rectangle(color_light_gray(),0,0,60,600);
 	
 	// Draw the menu shapes.
-	fill_circle(ColorGreen, MENU_CIRCLE);
-	fill_triangle(ColorGreen, MENU_TRIANGLE);
-	fill_rectangle(ColorGreen, MENU_RECT);
-	fill_ellipse(ColorGreen, MENU_ELLIPSE);
+	fill_circle(color_green(), MENU_CIRCLE);
+	fill_triangle(color_green(), MENU_TRIANGLE);
+	fill_rectangle(color_green(), MENU_RECT);
+	fill_ellipse(color_green(), MENU_ELLIPSE);
 	
 	// Redraw the selected shape
 	switch(selected_shape)
 	{
 	    case RECTANGLE: 
-	        draw_rectangle(ColorBlack, MENU_RECT);
+	        draw_rectangle(color_black(), MENU_RECT);
             break;
         case TRIANGLE:
-		    draw_triangle(ColorBlack, MENU_TRIANGLE);
+		    draw_triangle(color_black(), MENU_TRIANGLE);
             break;
         case CIRCLE:
-		    draw_circle(ColorBlack, MENU_CIRCLE);
+		    draw_circle(color_black(), MENU_CIRCLE);
             break;
         case ELLIPSE:
-            draw_ellipse(ColorBlack, MENU_ELLIPSE);
+            draw_ellipse(color_black(), MENU_ELLIPSE);
             break;
-        case UNKNOWN:
+        case NONE:
             break;
         // Do nothing for default...
 	}
@@ -117,7 +118,7 @@ void draw_shape(shape &s)
 		case ELLIPSE:
 			fill_ellipse(s.fill_color,s.data.ellipse);
 			break;
-		case UNKNOWN:
+		case NONE:
 			break;
 	}//end switch
 }
@@ -126,7 +127,7 @@ void draw_shape(shape &s)
 void do_drawing(drawing &d)
 {	
     // Clear screen and redraw menu
-    clear_screen(ColorWhite);
+    clear_screen();
     draw_shapes_menu(d.selected_shape);
     
 	// Draw the shapes
@@ -141,11 +142,11 @@ void do_drawing(drawing &d)
 // ============================
 
 // Add a rectangle to the drawing
-void add_rectangle(shape &s, point2d pt)
+void add_rectangle(shape &s, point_2d pt)
 {
     // Set the shape
 	s.type = RECTANGLE;
-	s.fill_color = ColorRed;
+	s.fill_color = color_red();
 	
 	// Copy in the menu rectangle
 	s.data.rect = MENU_RECT;
@@ -156,11 +157,11 @@ void add_rectangle(shape &s, point2d pt)
 }
 
 // Add a circle to the drawing
-void add_circle(shape &s, point2d pt)
+void add_circle(shape &s, point_2d pt)
 {
     // Set the shape
 	s.type = CIRCLE;
-	s.fill_color = ColorBlue;
+	s.fill_color = color_blue();
 	
 	// Copy in the menu circle radius
 	s.data.circ.radius = MENU_CIRCLE.radius;
@@ -169,33 +170,30 @@ void add_circle(shape &s, point2d pt)
 	s.data.circ.center = pt;
 }//add circle
 
-// Add a triangle to the drawing
-void add_triangle(shape &s, point2d pt)
+//Add a triangle to the drawing
+void add_triangle(shape &s, point_2d pt)
 {
-	point2d pt1;
-	
 	// Set the type and color
 	s.type = TRIANGLE;
-	s.fill_color = ColorYellow;
+	s.fill_color = color_yellow();
 	
 	// Set point 1 to pt
-	s.data.tri[0] = pt;
+	s.data.tri.points[0] = pt;
 	
 	// Offset point -20 x, 50 y
-	pt1.x = -20;
-	pt1.y = 50;
-	s.data.tri[1] = point_add(pt, pt1);
+	s.data.tri.points[1].x = pt.x - 20;
+	s.data.tri.points[1].y = pt.y + 50;
 	
 	// Offset point 20 x, 50 y
-	pt1.x = 20;
-	s.data.tri[2] = point_add(pt, pt1);
+	s.data.tri.points[2].x = pt.x + 20;
+	s.data.tri.points[2].y = pt.y + 50;
 }//add triangle
 
-void add_ellipse(shape &s, point2d pt)
+void add_ellipse(shape &s, point_2d pt)
 {
     // Setup the shape
 	s.type = ELLIPSE;
-	s.fill_color = ColorGreen;
+	s.fill_color = color_green();
 	
 	// Copy in menu ellipse
 	s.data.ellipse = MENU_ELLIPSE;
@@ -208,38 +206,38 @@ void add_ellipse(shape &s, point2d pt)
 //input processing procedures
 bool process_key(drawing &d)
 {
-	if(key_down(VK_Q)) return true;
-	if(key_down(VK_C))
+	if(key_down(Q_KEY)) return true;
+	if(key_down(C_KEY))
 	{
 		d.index = 0;
-		for(int i = 0; i < MAX_SHAPES ;++i) d.shapes[i].type = UNKNOWN;
+		for(int i = 0; i < MAX_SHAPES ;++i) d.shapes[i].type = NONE;
 	}
 	return false;	
 }
 
 // Check if the user has clicked in a shape in the toolbar
-void process_menu_click(drawing &d, point2d pt)
+void process_menu_click(drawing &d, point_2d pt)
 {	
-	if(point_in_rect(&pt,&MENU_RECT))
+	if(point_in_rectangle(pt,MENU_RECT))
 	{
 		d.selected_shape = RECTANGLE;
 	}
-	if(point_in_triangle(&pt,MENU_TRIANGLE))
+	if(point_in_triangle(pt,MENU_TRIANGLE))
 	{
 		d.selected_shape = TRIANGLE;
 	}
-	if(point_in_circle(&pt,&MENU_CIRCLE))
+	if(point_in_circle(pt,MENU_CIRCLE))
 	{
 		d.selected_shape = CIRCLE;
 	}
-	if(point_in_rect(&pt,&MENU_ELLIPSE))
+	if(point_in_rectangle(pt,MENU_ELLIPSE))
 	{
 		d.selected_shape = ELLIPSE;
 	}
 }
 
 // Add a shape to the canvas
-void process_canvas_click(drawing &d, point2d pt)
+void process_canvas_click(drawing &d, point_2d pt)
 {
     // Try to add a shape... is the current index < maximum?
 	if(d.index < MAX_SHAPES)
@@ -274,7 +272,7 @@ bool process_input(drawing &d)
 {
 	if(mouse_clicked(LEFT_BUTTON))
 	{
-		point2d pt = mouse_position();
+		point_2d pt = mouse_position();
 		
 		if(pt.x < 60) 	
 		    process_menu_click(d,pt);
@@ -283,7 +281,7 @@ bool process_input(drawing &d)
 	}//if LEFT BUTTON
 	
 	if(any_key_pressed())  
-	    return process_key(d);
+	    return true;
 	else
 		return false;
 }//process input
@@ -296,7 +294,7 @@ void setup_drawing(drawing &d)
     // All shapes are unknown...
 	for(int i = 0; i < MAX_SHAPES ;++i) 
 	{
-	    d.shapes[i].type = UNKNOWN;
+	    d.shapes[i].type = NONE;
     }
 }
 
@@ -310,8 +308,7 @@ int main()
 	// Initialise the drawing with empty data...
     setup_drawing(my_drawing);
 			
-    open_graphics_window("Draw Shapes", 800, 500);
-    load_default_colors();
+    open_window("Draw Shapes", 800, 500);
     
     do
     {
@@ -320,9 +317,8 @@ int main()
 		
 		do_drawing(my_drawing);
         refresh_screen();
-    } while ( ! window_close_requested() && !quit);
-     
-    release_all_resources();
+    } while ( ! quit_requested() && !quit);
+
     return 0;
 }
 

--- a/code/c/types/lights.cpp
+++ b/code/c/types/lights.cpp
@@ -1,8 +1,9 @@
-/* Program: lights (C++, SwinGame) */
+/* Program: lights (C++, Splashkit) */
 #include <stdbool.h>
 #include <strings.h>
 #include <stdio.h>
-#include "SwinGame.h"
+#include <cstring>
+#include "splashkit.h"
 
 // =====================
 // = Delcare Constants =
@@ -27,7 +28,7 @@ typedef struct
 {
     bool        is_on;      // is the light on?
     light_size  size;       // size of the light
-    point2d     position;   // location of the light (top left)
+    point_2d     position;   // location of the light (top left)
 } light;
 
 
@@ -36,7 +37,7 @@ typedef struct
 // ====================================
 
 // Sets up a new light, and returns its data
-light create_light(bool on, light_size sz, point2d pos)
+light create_light(bool on, light_size sz, point_2d pos)
 {
     light result;
     
@@ -56,13 +57,13 @@ bitmap light_bitmap(light &l)
     switch (l.size)
     {
         case SMALL_LIGHT:
-            strncat(name, "small light", 11);
+            strncat(name, "small light", 14);
             break;
         case MEDIUM_LIGHT:
-            strncat(name, "medium light", 12);
+            strncat(name, "medium light", 14);
             break;
         case LARGE_LIGHT:
-            strncat(name, "large light", 11);
+            strncat(name, "large light", 14);
             break;
         default:
             return NULL;
@@ -70,9 +71,9 @@ bitmap light_bitmap(light &l)
     
     // the end of the name is based on if the light is on/off
     if (l.is_on)
-        strncat(name, " on", 4);
+        strncat(name, " on", 6);
     else
-        strncat(name, " off", 4);
+        strncat(name, " off", 6);
     
     // return the bitmap with that name
     return bitmap_named(name);    
@@ -81,7 +82,7 @@ bitmap light_bitmap(light &l)
 // Draw the light "l" to the screen
 void draw_light(light &l)
 {
-    draw_bitmap(light_bitmap(l), l.position);
+    draw_bitmap(light_bitmap(l), l.position.x, l.position.y);
 }
 
 // Draw all of the lights in "lights"
@@ -98,7 +99,7 @@ void draw_lights(light lights[], int count)
 // Is the light currently under the mouse?
 bool light_under_mouse(light &l)
 {
-    point2d mouse;
+    point_2d mouse;
     bitmap light_bmp;
     
     // get the mouse position
@@ -108,7 +109,7 @@ bool light_under_mouse(light &l)
     
     // Simple version using a bounded rectangle
     //return point_in_rect(mouse, bitmap_rectangle(l.position.x, l.position.y, light_bmp));
-    return bitmap_point_collision(light_bmp, l.position.x, l.position.y, mouse);
+    return bitmap_point_collision(light_bmp, l.position, mouse);
 }
 
 // Check if the lights have been changed (clicked)
@@ -136,14 +137,14 @@ void update_lights(light lights[], int count)
 void load_bitmaps()
 {
     // Load "on" lights
-    load_bitmap_named("small light on", "on_sml.png");
-    load_bitmap_named("medium light on", "on_med.png");
-    load_bitmap_named("large light on", "on.png");
+    load_bitmap("small light on", "on_sml.png");
+    load_bitmap("medium light on", "on_med.png");
+    load_bitmap("large light on", "on.png");
     
     // Load "off" lights
-    load_bitmap_named("small light off", "off_sml.png");
-    load_bitmap_named("medium light off", "off_med.png");
-    load_bitmap_named("large light off", "off.png");    
+    load_bitmap("small light off", "off_sml.png");
+    load_bitmap("medium light off", "off_med.png");
+    load_bitmap("large light off", "off.png"); 
 }
 
 // ======================
@@ -155,9 +156,7 @@ int main(int argc, char* argv[])
     // Create a number of lights
     light lights[NUM_LIGHTS];
     
-    open_audio();
-    open_graphics_window("Lights", 800, 600);
-    load_default_colors();
+    open_window("Lights", 800, 600);
     
     load_bitmaps();
     
@@ -176,9 +175,9 @@ int main(int argc, char* argv[])
         clear_screen();
         draw_lights(lights, NUM_LIGHTS);
         refresh_screen();
-    } while ( ! window_close_requested() );
+        
+    } while ( ! quit_requested() );
 
-    release_all_resources();
-    close_audio();
+
     return 0;
 }


### PR DESCRIPTION
This PR replaces old swingame.h files with Splashkit.h compatible files. The files replaced in this PR are “swingame-comet.c”, “water-tank.c”, “complete-shape-drawing.cpp”, “lights.cpp”, “bike-race.c” and “bubble-game.c”. Each of these files had the most minimal changes possible to be compiled for Splashkit. This was to maintain the original coding standards of Andrew Cain.

The testing images and resources used were not included in this PR as it is unknown what resources the author wishes to use for these programs.

These images provided show the compiled files working:

**1: “swingame-comet.c”**
![comet](https://user-images.githubusercontent.com/48664520/168732344-3cc79f53-9fbe-458d-91ee-90970d982d7d.PNG)

**2: “water-tank.c”**
![water](https://user-images.githubusercontent.com/48664520/168732368-2594a49c-24c3-4e64-85d5-71f9e87ac50b.PNG)

**3: “complete-shape-drawing.cpp”**
![shapes](https://user-images.githubusercontent.com/48664520/168732391-eea8ffb0-9a78-42eb-a7cf-fadb3cbba4b5.PNG)

**4: “lights.cpp”**
![light](https://user-images.githubusercontent.com/48664520/168732412-d23749ba-5341-48a0-907b-a189003dc096.PNG)

**4: “bike-race.c”**
![bikerace](https://user-images.githubusercontent.com/48664520/168732423-a45dce06-42a7-4456-97de-b9af47d4a405.PNG)

6: “bubble-game.c"
![bubble](https://user-images.githubusercontent.com/48664520/168732435-fa371c21-607c-47c6-a69e-13fff57f3f76.PNG)
game.c”
